### PR TITLE
smooth fiducials recovery behaviour

### DIFF
--- a/ground_fiducials/launch/sim_smooth_fiducials.launch
+++ b/ground_fiducials/launch/sim_smooth_fiducials.launch
@@ -18,7 +18,7 @@
     </include>
 
     <!-- Run move_basic to drive the robot -->
-    <node name="move_basic" pkg="move_basic" type="move_basic" output="screen">
+    <node name="move_basic" pkg="move_basic" type="move_basic" output="log">
         <!-- Footprint for obstacle detection -->
         <param name="robot_width" value="0.20"/>
         <param name="robot_front_length" value="0.1"/>

--- a/ground_fiducials/scripts/smooth_fiducials.py
+++ b/ground_fiducials/scripts/smooth_fiducials.py
@@ -9,7 +9,7 @@ import tf2_ros
 import numpy as np
 import traceback
 
-from geometry_msgs.msg import PoseStamped, TransformStamped, Twist, Vector3Stamped
+from geometry_msgs.msg import PoseStamped, TransformStamped, Twist, Vector3Stamped, Vector3
 from fiducial_msgs.msg import FiducialTransformArray, FiducialTransform
 from actionlib_msgs.msg import GoalStatusArray, GoalStatus
 from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal
@@ -18,8 +18,8 @@ from copy import deepcopy
 from tf2_geometry_msgs import do_transform_vector3
 from tf.transformations import quaternion_from_euler, euler_from_quaternion
 
-UPDATE_RATE = 30
 LAUNCH_DISTANCE = 2.0
+ABORT_DISTANCE = 5.0
 
 def arrayify(string):
 	string = string.replace(' ', '').replace('[','').replace(']','')
@@ -48,45 +48,13 @@ class GroundFiducials:
 		self.client = actionlib.SimpleActionClient('move_base',MoveBaseAction)
 		self.client.wait_for_server()
 
+		self.last_fid_translation = None
 		self.fid_transform = None
 		self.fid_action = None
 
 		self.positionlist = []
 
 		self.fid_subscriber = rospy.Subscriber("/fiducial_transforms", FiducialTransformArray, self.fiducial_callback)
-
-		#self.velocity_publisher = rospy.Publisher('/cmd_vel', Twist, queue_size=10)
-
-		
-	# def rotate(self):
-
-	# 	pose_st = PoseStamped()
-	# 	q_rot = quaternion_from_euler(0, 0, -math.radians(ROTATION_ANGLE))
-	# 	pose_st.pose.position.x = 0
-	# 	pose_st.pose.position.y = 0
-	# 	pose_st.pose.position.z = 0
-
-	# 	pose_st.pose.orientation.x = q_rot[0]
-	# 	pose_st.pose.orientation.y = q_rot[1]
-	# 	pose_st.pose.orientation.z = q_rot[2]
-	# 	pose_st.pose.orientation.w = q_rot[3]
-	# 	pose_st.header.frame_id = "base_link"
-	# 	pose_st.header.stamp = rospy.Time.now()
-
-	# 	goal = MoveBaseGoal()
-	# 	goal.target_pose = pose_st
-	# 	self.rotate_goal = self.client.send_goal(goal)
-
-	# 	success = self.client.wait_for_result()
-
-	# 	if success and self.client.get_state() == GoalStatus.SUCCEEDED:
-	# 		rospy.sleep(1.0)
-	# 		self.state = 'SEARCH'
-
-	# 	if self.angle == -2*ROTATION_ANGLE:
-	# 		self.angle = 2*ROTATION_ANGLE
-	# 	else:
-	# 		self.angle = -2*ROTATION_ANGLE
 
 	def transformVector(self, x, y, z, quat):
 
@@ -131,14 +99,20 @@ class GroundFiducials:
 					print("---- Transform sent. ----")
 
 					try:
-						transform = self.buffer.lookup_transform("odom", t.child_frame_id, t.header.stamp, rospy.Duration(1.0))
-						if math.fabs(self.get_marker_error(transform)) < 10:
-							self.fid_transform = transform
+						pose = self.buffer.lookup_transform("odom", t.child_frame_id, t.header.stamp, rospy.Duration(1.0))
+						if math.fabs(self.get_marker_error(pose)) < 10:
+
+							self.last_fid_translation = Vector3()
+							self.last_fid_translation.x = pose.transform.translation.x
+							self.last_fid_translation.y = pose.transform.translation.y
+
+							self.fid_transform = pose
 							self.fid_action = self.fids[fiducials[0].fiducial_id]
+
 							self.new_fid_goal()
 						else:
 							self.fid_subscriber = rospy.Subscriber("/fiducial_transforms", FiducialTransformArray, self.fiducial_callback)
-						print("------------- MARKER ERROR: "+str(self.get_marker_error(transform))+" ------------")
+						print("------------- MARKER ERROR: "+str(self.get_marker_error(pose))+" ------------")
 					except:
 						print("Couldn't find transform.")
 						self.fid_subscriber = rospy.Subscriber("/fiducial_transforms", FiducialTransformArray, self.fiducial_callback)
@@ -193,17 +167,49 @@ class GroundFiducials:
 		self.process_goal(self.fid_transform, rospy.Time.now())
 
 	def new_goal(self):
+
+		print("DIST:"+str(self.distance_to_base(self.last_fid_translation)))
+
+		if self.distance_to_base(self.last_fid_translation) > ABORT_DISTANCE:
+			self.recovery_rotation()
+			return
+
 		self.fid_subscriber = rospy.Subscriber("/fiducial_transforms", FiducialTransformArray, self.fiducial_callback)
 
 		self.reproject_transform(LAUNCH_DISTANCE)
 		self.process_goal(self.fid_transform, rospy.Time.now())
 		print("Next goal published")
 
-	def distance_to_base(self):
+	def recovery_rotation(self):
+
+		rospy.sleep(1.0)
+
+		pose_st = PoseStamped()
+		pose_st.pose.position.x = 0
+		pose_st.pose.position.y = 0
+		pose_st.pose.position.z = 0
+
+		q_rot = quaternion_from_euler(0, 0, math.radians(45))
+
+		pose_st.pose.orientation.x = q_rot[0]
+		pose_st.pose.orientation.y = q_rot[1]
+		pose_st.pose.orientation.z = q_rot[2]
+		pose_st.pose.orientation.w = q_rot[3]
+		pose_st.header.frame_id = "base_link"
+		pose_st.header.stamp = rospy.Time.now()
+
+		goal = MoveBaseGoal()
+		goal.target_pose = pose_st
+		self.client.send_goal(goal)
+
+		print("! Recovery goal sent !")
+		rospy.sleep(1.0)
+
+
+	def distance_to_base(self, translation):
 		try:
 			pose = self.buffer.lookup_transform("odom", "base_link", rospy.Time.now(), rospy.Duration(0.5))
-			dist = (self.fid_transform.transform.translation.x - pose.transform.translation.x) ** 2 
-			dist += (self.fid_transform.transform.translation.y - pose.transform.translation.y) ** 2 
+			dist = (translation.x - pose.transform.translation.x) ** 2 + (translation.y - pose.transform.translation.y) ** 2 
 			dist = math.sqrt(dist)
 			return dist
 		except:
@@ -212,14 +218,13 @@ class GroundFiducials:
 if __name__ == '__main__':
 	try:
 		t = GroundFiducials()
-		sleep_time = 1.0/UPDATE_RATE
+		rate = rospy.Rate(10)
 		while not rospy.is_shutdown():
-			rospy.sleep(sleep_time)
-
+			rate.sleep()
 			if t.fid_transform != None and t.fid_action == "GO":
-				dist = t.distance_to_base()
-				print("DIST:"+str(dist))
-				if dist > 0 and dist < 0.65:
+				dist = t.distance_to_base(t.fid_transform.transform.translation)
+				#print("DIST:"+str(dist))
+				if dist > 0 and dist < 0.7:
 					t.new_goal()
 
 


### PR DESCRIPTION
Smooth fiducials should now stop 6m away from last seen fiducial if it doesn't see anything and will do a 45 degree incremental 360 turn until it sees something. Seems to pretty reliably fix those near misses. Timing is probably a bit off, but that's gotta be rechecked on the real robot.